### PR TITLE
add:エラーメッセージ

### DIFF
--- a/app/views/posts/new.html.erb
+++ b/app/views/posts/new.html.erb
@@ -1,5 +1,9 @@
 <div class="text-center max-w-2xl mx-auto shadow-md mt-10">
-  <h1 class="mb-4 text-center text-2xl font-bold text-gray-900 md:mb-8 py-5 lg:text-3xl">新規投稿</h1>
+  <h1 class="mb-4 text-center text-2xl font-bold text-gray-900 md:mb-8 py-2 lg:text-3xl">新規投稿</h1>
+    <div class="pb-4 text-red-700">
+      <%= render 'shared/error_messages', object: @post %>
+    </div>
+
     <%= form_with model: @post, class: "new_post" do |f| %>
     <div class="mx-auto max-w-lg rounded-lg border flex flex-col gap-4 md:p-8">
       <div>

--- a/app/views/shared/_error_messages.html.erb
+++ b/app/views/shared/_error_messages.html.erb
@@ -1,0 +1,9 @@
+<% if object.errors.any? %>
+  <ul>
+    <div id="error_explanation">
+      <% object.errors.each do |error| %>
+        <li><%= error.full_message %></li>
+      <% end %>
+    </div>
+  </ul>
+<% end %>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,0 +1,12 @@
+ja:
+  activerecord:
+    models:
+      post: "投稿"
+    attributes:
+      post:
+        temple_name: "寺院・史跡名"
+        location: "場所"
+        comment: "コメント"
+    errors:
+      messages:
+        blank: "を入力してください"


### PR DESCRIPTION
### 概要
 - 掲示板投稿時における、バリデーションエラーに関するメッセージをビューに表示。
 - エラーメッセージ日本語化のため`ja.yml`ファイルを作成。
 
### 変更点
1. `app/views/shared/_error_messages.html.erb`の作成
   - エラーメッセージを部分テンプレートとして作成。`new.html.erb`でレンダリング。
2. `config/locales/ja.yml` の作成
   - 日本語化のため、以下を追加。
```
ja:
  activerecord:
    models:
      post: "投稿"
    attributes:
      post:
        temple_name: "寺院・史跡名"
        location: "場所"
        comment: "コメント"
    errors:
      messages:
        blank: "を入力してください"

```