### PR TITLE
update:複数枚の画像投稿

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -47,3 +47,14 @@
     background-image: url("mobile_gradation.png");
   }
 }
+
+.swiper-container {
+  width: 100%;
+  height: 250px; /* 必要に応じて調整 */
+}
+
+.swiper-slide {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -44,6 +44,6 @@ class PostsController < ApplicationController
   private
 
   def post_params
-    params.require(:post).permit(:temple_name, :location, :comment, :post_image, :post_image_cache)
+    params.require(:post).permit(:temple_name, :location, :comment, {post_images: []})
   end
 end

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -34,7 +34,7 @@ class PostsController < ApplicationController
       render :edit, status: :unprocessable_entity
     end
   end
-  
+
   def destroy
     post = current_user.posts.find(params[:id])
     post.destroy!
@@ -44,6 +44,6 @@ class PostsController < ApplicationController
   private
 
   def post_params
-    params.require(:post).permit(:temple_name, :location, :comment, {post_images: []})
+    params.require(:post).permit(:temple_name, :location, :comment, { post_images: [] })
   end
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -2,8 +2,16 @@ class Post < ApplicationRecord
   validates :temple_name, presence: true, length: { maximum: 20 }
   validates :location, presence: true, length: { maximum: 20 }
   validates :comment, presence: true, length: { maximum: 255 }
+  validate :validate_image_coutn
 
-  mount_uploader :post_image, PostImageUploader
-
+  mount_uploaders :post_images, PostImageUploader
   belongs_to :user
+
+  private
+
+  def validate_image_coutn
+    if post_images.count > 5
+      errors.add(:post_images, "は5枚以下にしてください。")
+    end
+  end
 end

--- a/app/uploaders/post_image_uploader.rb
+++ b/app/uploaders/post_image_uploader.rb
@@ -17,7 +17,7 @@ class PostImageUploader < CarrierWave::Uploader::Base
   def default_url(*args)
   # For Rails 3.1+ asset pipeline compatibility:
   # ActionController::Base.helpers.asset_path("fallback/" + [version_name, "default.png"].compact.join('_'))
-  #    "/images/fallback/" + [version_name, "default.png"].compact.join('_')
+    #    "/images/fallback/" + [version_name, "default.png"].compact.join('_')
     "default.png"
   end
 

--- a/app/uploaders/post_image_uploader.rb
+++ b/app/uploaders/post_image_uploader.rb
@@ -16,7 +16,7 @@ class PostImageUploader < CarrierWave::Uploader::Base
   # Provide a default URL as a default if there hasn't been a file uploaded:
   def default_url(*args)
   # For Rails 3.1+ asset pipeline compatibility:
-  # ActionController::Base.helpers.asset_path("fallback/" + [version_name, "default.png"].compact.join('_'))
+    # ActionController::Base.helpers.asset_path("fallback/" + [version_name, "default.png"].compact.join('_'))
     #  "/images/fallback/" + [version_name, "default.png"].compact.join('_')
     "default.png"
   end

--- a/app/uploaders/post_image_uploader.rb
+++ b/app/uploaders/post_image_uploader.rb
@@ -17,7 +17,7 @@ class PostImageUploader < CarrierWave::Uploader::Base
   def default_url(*args)
   # For Rails 3.1+ asset pipeline compatibility:
   # ActionController::Base.helpers.asset_path("fallback/" + [version_name, "default.png"].compact.join('_'))
-    #    "/images/fallback/" + [version_name, "default.png"].compact.join('_')
+    #  "/images/fallback/" + [version_name, "default.png"].compact.join('_')
     "default.png"
   end
 

--- a/app/uploaders/post_image_uploader.rb
+++ b/app/uploaders/post_image_uploader.rb
@@ -17,7 +17,7 @@ class PostImageUploader < CarrierWave::Uploader::Base
   def default_url(*args)
   # For Rails 3.1+ asset pipeline compatibility:
   # ActionController::Base.helpers.asset_path("fallback/" + [version_name, "default.png"].compact.join('_'))
-  # "/images/fallback/" + [version_name, "default.png"].compact.join('_')
+  #   "/images/fallback/" + [version_name, "default.png"].compact.join('_')
     "default.png"
   end
 

--- a/app/uploaders/post_image_uploader.rb
+++ b/app/uploaders/post_image_uploader.rb
@@ -17,7 +17,7 @@ class PostImageUploader < CarrierWave::Uploader::Base
   def default_url(*args)
   # For Rails 3.1+ asset pipeline compatibility:
   # ActionController::Base.helpers.asset_path("fallback/" + [version_name, "default.png"].compact.join('_'))
-  #   "/images/fallback/" + [version_name, "default.png"].compact.join('_')
+  #    "/images/fallback/" + [version_name, "default.png"].compact.join('_')
     "default.png"
   end
 

--- a/app/uploaders/post_image_uploader.rb
+++ b/app/uploaders/post_image_uploader.rb
@@ -15,7 +15,7 @@ class PostImageUploader < CarrierWave::Uploader::Base
 
   # Provide a default URL as a default if there hasn't been a file uploaded:
   def default_url(*args)
-  # For Rails 3.1+ asset pipeline compatibility:
+    # For Rails 3.1+ asset pipeline compatibility:
     # ActionController::Base.helpers.asset_path("fallback/" + [version_name, "default.png"].compact.join('_'))
     #  "/images/fallback/" + [version_name, "default.png"].compact.join('_')
     "default.png"

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -19,6 +19,8 @@
     <%= javascript_include_tag "application", "data-turbo-track": "reload", type: "module" %>
     <script src="https://kit.fontawesome.com/c862512458.js" crossorigin="anonymous"></script>
     <%= display_meta_tags(default_meta_tags) %>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/swiper@11/swiper-bundle.min.css">
+    <script src="https://cdn.jsdelivr.net/npm/swiper@11/swiper-bundle.min.js"></script>
   </head>
 
   <body>

--- a/app/views/posts/edit.html.erb
+++ b/app/views/posts/edit.html.erb
@@ -16,8 +16,8 @@
       </div>
       <div>
         <%= f.label :画像, class: "mb-2 inline-block text-sm text-gray-800 sm:text-base" %>
-        <%= f.file_field :post_image, class: "form-control w-full border bg-gray-50 px-3 py-2 text-gray-800 outline-none ring-indigo-300 transition duration-100 focus:ring", accept: 'image/*' %>
-        <%= f.hidden_field :post_image_cache %>
+        <%= f.file_field :post_images, class: "form-control w-full border bg-gray-50 px-3 py-2 text-gray-800 outline-none ring-indigo-300 transition duration-100 focus:ring", accept: 'image/*' %>
+        <%= f.hidden_field :post_images_cache %>
       </div>
       <div>
         <%= f.label :コメント, class: "mb-2 inline-block text-sm text-gray-800 sm:text-base" %>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -6,25 +6,28 @@
       <p class="py-3 mx-auto max-w-screen-md text-center md:text-lg">あなたが訪れた寺院・史跡名跡を共有</p>
     </div>
 
-      <!-- カード全体 -->
-    <div class="px-8 grid grid-cols-1 sm:grid-cols-2 md:grid-cols-2 lg:grid-cols-3 gap-4">
+    <div class="px-10 py-2 grid grid-cols-1 sm:grid-cols-2 md:grid-cols-2 lg:grid-cols-3 gap-4 shadow-md">
       <% if @posts.present? %>
         <% @posts.each do |post| %>
-          <!-- 個別カード -->
           <div class="overflow-hidden bg-white-90 shadow-md rounded">
-            <!-- 写真 -->
-            <div class="group relative block h-48 overflow-hidden bg-gray-100 md:h-64">
-              <%= link_to image_tag(post.post_image_url, loading: "lazy", alt: "post image", class: "absolute inset-0 h-full w-full object-center transition duration-500 group-hover:scale-110 ",width: "300", height: "200"), post_path(post) %>
+            <div class="swiper-container mySwiper">
+              <div class="swiper-wrapper">
+                <% post.post_images.each do |image| %>
+                  <div class="swiper-slide group relative block h-40 overflow-hidden bg-gray-100 md:h-64">
+                    <%= link_to image_tag(image.url, loading: "lazy", alt: "post images", class: "absolute inset-0 h-full w-full object-center transition duration-500 group-hover:scale-110 "), post_path(post) %>
+                  </div>
+                <% end %>
+                <div class="swiper-pagination"></div>
+              </div>
             </div>
 
             <div class="p-1 sm:p-1">
-
               <div class="flex items-center">
                 <h2 class="text-md font-semibold"><%= post.temple_name %></h2>
                 ｜<span class="text-xs text-gray-700"><%= post.location%></span>
               </div>
 
-              <p class="text-gray-500 break-words text-xs mt-2"><%= truncate(post.comment, length: 100) %></p>
+              <p class="text-gray-500 break-words lg:h-12 text-xs mt-1"><%= truncate(post.comment, length: 90) %></p>
 
               <div class="mt-auto flex items-center items-end justify-between">
                 <div class="flex items-center gap-2">
@@ -48,3 +51,20 @@
     <% end %>
   </div>
 </div>
+
+<script>
+document.addEventListener('turbo:load', function () {
+  var swiper = new Swiper(".mySwiper", {
+    spaceBetween: 30,
+    effect: "fade",
+    pagination: {
+      el: ".swiper-pagination",
+      clickable: true,
+    },
+    navigation: {
+      nextEl: ".swiper-button-next",
+      prevEl: ".swiper-button-prev",
+    },
+  });
+});
+</script>

--- a/app/views/posts/new.html.erb
+++ b/app/views/posts/new.html.erb
@@ -16,8 +16,8 @@
       </div>
       <div>
         <%= f.label :画像, class: "mb-2 inline-block text-sm text-gray-800 sm:text-base" %>
-        <%= f.file_field :post_image, class: "form-control w-full border bg-gray-50 px-3 py-2 text-gray-800 outline-none ring-indigo-300 transition duration-100 focus:ring", accept: 'image/*' %>
-        <%= f.hidden_field :post_image_cache %>
+        <%= f.file_field :post_images, multiple: true, class: "form-control w-full border bg-gray-50 px-3 py-2 text-gray-800 outline-none ring-indigo-300 transition duration-100 focus:ring", accept: 'image/*' %>
+        <%= f.hidden_field :post_images_cache %>
       </div>
       <div>
         <%= f.label :コメント, class: "mb-2 inline-block text-sm text-gray-800 sm:text-base" %>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -1,19 +1,25 @@
 <div class="mx-auto max-w-xl px-4 py-6 md:px-8">
 <!-- 個別カード -->
 <div class="overflow-hidden bg-white-90 px-2 md:px-6 lg:px-8 shadow-md rounded">
-  <!-- 写真 -->
-  <div class="relative flex items-center justify-center bg-gray-90">
-    <%= image_tag @post.post_image_url, loading: "lazy", alt: "", class: "max-w-[500px] max-h-[500px] w-auto h-auto object-cover object-center transition duration-200 group-hover:scale-110" %>
-  </div>
+  <div class="swiper-container mySwiper">
+    <div class="swiper-wrapper">
+      <% @post.post_images.each do |image| %>
+        <div class="swiper-slide relative items-center justify-center bg-gray-90"> 
+          <%= image_tag image.url, loading: "lazy", alt: "", class: "object-cover h-full w-full transition duration-200 group-hover:scale-110 mt-3" %>
+        </div>
+      <% end %>
+      <div class="swiper-pagination"></div>
+    </div>
+  </div>  
 
   <div class="sm:p-3 pl-4 flex-grow">
-    <div class="flex items-center">
+    <div class="flex items-center mt-3">
         <h2 class="text-xl font-semibold"><%= @post.temple_name %></h2>
         ｜<span class="text-xs text-gray-700"><%= @post.location %></span>
     </div>
    
 
-    <p class="text-gray-500 mt-2 break-words"><%= truncate(@post.comment, length: 100) %></p>
+    <p class="text-gray-500 mt-2 break-words"><%=@post.comment%></p>
 
     <div class="mt-auto flex items-end justify-between mb-2">
       <div class="flex items-center">

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,4 +1,4 @@
-<header class="shadow-sm body-font p-5 border-b lg:border-b-6 lg:h-18">
+<header class="shadow-sm body-font p-1 border-b lg:border-b-6 lg:h-18">
   <div class="flex justify-between md:flex-row text-gray-900">
     <a href="<%= root_path %>" class="flex title-font font-medium items-center mb-4 md:mb-0">
       <%= image_tag('22225678.png', alt: "名僧診断", class: 'w-10 h-10 text-white p-0.5 bg-blue-300 rounded-full') %>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -7,6 +7,7 @@ ja:
         temple_name: "寺院・史跡名"
         location: "場所"
         comment: "コメント"
+        post_images: "画像"
     errors:
       messages:
         blank: "を入力してください"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,4 +17,7 @@ Rails.application.routes.draw do
   root "home#index"
   resources :personality_tests, only: [ :new, :create, :show ]
   resources :posts, only: [ :index, :new, :create, :edit, :show, :edit, :update, :destroy ]
+  # resources :posts do
+  #  resources :post_images, :only => [:create, :destroy]
+  # end
 end

--- a/db/migrate/20241224082312_change_post_to_json.rb
+++ b/db/migrate/20241224082312_change_post_to_json.rb
@@ -1,0 +1,5 @@
+class ChangePostToJson < ActiveRecord::Migration[7.2]
+  def change
+    change_column :posts, :post_image, :json, default: [], using: 'post_image::json'
+  end
+end

--- a/db/migrate/20241224091412_rename_post_image_in_posts.rb
+++ b/db/migrate/20241224091412_rename_post_image_in_posts.rb
@@ -1,0 +1,5 @@
+class RenamePostImageInPosts < ActiveRecord::Migration[7.2]
+  def change
+    rename_column :posts, :post_image, :post_images
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_12_23_005308) do
+ActiveRecord::Schema[7.2].define(version: 2024_12_24_091412) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -33,7 +33,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_12_23_005308) do
     t.bigint "user_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.string "post_image"
+    t.json "post_images", default: []
     t.index ["user_id"], name: "index_posts_on_user_id"
   end
 


### PR DESCRIPTION
### 概要
 - 複数枚の画像投稿実装。
 - swiperを導入し投稿した画像をスライド形式で表示
### 変更点
1. `Posts`テーブルのカラムを`json`形式に変更
   -  `t.string "post_image"`を `t.json "post_images"`に変更し複数枚に対応可能なカラムへ
   - `posts_controller.rb`において`post_images: []`と配列でデータを渡すように変更。
   - カスタムバリデーション`validate_image_coutn` を作成。画像の投稿枚数を５枚までに設定
2. CDNでのswiperの導入。