### PR TITLE
add:マイページ実装

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -50,7 +50,7 @@
 
 .swiper-container {
   width: 100%;
-  height: 250px; /* 必要に応じて調整 */
+  height: 240px; /* 必要に応じて調整 */
 }
 
 .swiper-slide {

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -9,7 +9,7 @@ class ProfilesController < ApplicationController
     if @user.update(user_params)
       redirect_to profile_path, success: "更新しました"
     else
-      flash.now['danger'] = "更新に失敗しました"
+      flash.now["danger"] = "更新に失敗しました"
       render :edit, status: :unprocessable_entity
     end
   end

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -1,0 +1,30 @@
+class ProfilesController < ApplicationController
+  before_action :set_user, only: %i[edit update]
+
+  def edit
+    @user = current_user
+  end
+
+  def update
+    if @user.update(user_params)
+      redirect_to profile_path, success: "更新しました"
+    else
+      flash.now['danger'] = "更新に失敗しました"
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
+  def show
+    @posts = current_user.posts
+  end
+
+  private
+
+  def set_user
+    @user = User.find(current_user.id)
+  end
+
+  def user_params
+    params.require(:user).permit(:name, :email)
+  end
+end

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -1,3 +1,22 @@
 // Entry point for the build script in your package.json
 import "@hotwired/turbo-rails"
 import "./controllers"
+
+document.addEventListener('turbo:load', function () {
+  var swiper = new Swiper(".mySwiper", {
+    spaceBetween: 30,
+    effect: "fade",
+    pagination: {
+      el: ".swiper-pagination",
+      clickable: true,
+    },
+    navigation: {
+      nextEl: ".swiper-button-next",
+      prevEl: ".swiper-button-prev",
+    },
+  });
+
+  Turbo.frame.find('posts').addEventListener('turbo:frame-load', function () {
+    swiper.update();  // Swiperの更新
+  });
+});

--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -1,0 +1,41 @@
+  <div class="px-14 py-2 grid grid-cols-1 sm:grid-cols-2 md:grid-cols-2 lg:grid-cols-3 gap-6 shadow-md">
+    <% if @posts.present? %>
+      <% @posts.each do |post| %>
+        <div class="overflow-hidden bg-white-90 shadow-md rounded">
+          <div class="swiper-container mySwiper">
+            <div class="swiper-wrapper">
+              <% post.post_images.each do |image| %>
+                <div class="swiper-slide group relative block h-40 overflow-hidden bg-gray-100 md:h-64">
+                  <%= link_to image_tag(image.url, loading: "lazy", alt: "post images", class: "absolute inset-0 h-full w-full object-cover object-center transition duration-500 group-hover:scale-110 "), post_path(post) %>
+                </div>
+              <% end %>
+                <div class="swiper-pagination"></div>
+            </div>
+          </div>
+
+          <div class="p-1 sm:p-1">
+            <div class="flex items-center">
+              <h2 class="text-md font-semibold"><%= post.temple_name %></h2>
+                ｜<span class="text-xs text-gray-700"><%= post.location%></span>
+            </div>
+
+            <p class="text-gray-500 break-words lg:h-12 text-xs mt-1"><%= truncate(post.comment, length: 90) %></p>
+
+            <div class="mt-auto flex items-center items-end justify-between">
+              <div class="flex items-center gap-2">
+                <div>
+                  <span class="block text-sm text-indigo-500"><%= post.user.name %></span>
+                </div>
+              </div>
+
+              <span class="px-2 py-1 text-xs text-gray-500"><%= post.created_at.strftime("%Y-%m-%d") %></span>
+            </div>
+          </div>
+        </div>
+      <% end %>
+    <% else %>
+      <div class="col-span-2 sm:col-span-2 md:col-span-3 flex items-center justify-center">
+        <p class="text-gray-700 text-center">掲示板がありません。</p>
+      </div>
+    <% end %>
+  </div>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -1,70 +1,9 @@
 <div class="py-1 sm:py-6 lg:py-7 mt-5">
   <div class="mx-auto max-w-screen-xl px-5 md:px-8">
-
     <div class="mb-5 md:mb-10">
       <h1 class="mb-4 text-center text-2xl font-bold md:mb-6 lg:text-3xl">投稿一覧</h1>
       <p class="py-3 mx-auto max-w-screen-md text-center md:text-lg">あなたが訪れた寺院・史跡名跡を共有</p>
     </div>
-
-    <div class="px-10 py-2 grid grid-cols-1 sm:grid-cols-2 md:grid-cols-2 lg:grid-cols-3 gap-4 shadow-md">
-      <% if @posts.present? %>
-        <% @posts.each do |post| %>
-          <div class="overflow-hidden bg-white-90 shadow-md rounded">
-            <div class="swiper-container mySwiper">
-              <div class="swiper-wrapper">
-                <% post.post_images.each do |image| %>
-                  <div class="swiper-slide group relative block h-40 overflow-hidden bg-gray-100 md:h-64">
-                    <%= link_to image_tag(image.url, loading: "lazy", alt: "post images", class: "absolute inset-0 h-full w-full object-center transition duration-500 group-hover:scale-110 "), post_path(post) %>
-                  </div>
-                <% end %>
-                <div class="swiper-pagination"></div>
-              </div>
-            </div>
-
-            <div class="p-1 sm:p-1">
-              <div class="flex items-center">
-                <h2 class="text-md font-semibold"><%= post.temple_name %></h2>
-                ｜<span class="text-xs text-gray-700"><%= post.location%></span>
-              </div>
-
-              <p class="text-gray-500 break-words lg:h-12 text-xs mt-1"><%= truncate(post.comment, length: 90) %></p>
-
-              <div class="mt-auto flex items-center items-end justify-between">
-                <div class="flex items-center gap-2">
-                  <div>
-                    <span class="block text-sm text-indigo-500"><%= post.user.name %></span>
-                  </div>
-                </div>
-
-                <span class="px-2 py-1 text-xs text-gray-500"><%= post.created_at.strftime("%Y-%m-%d") %></span>
-              </div>
-            </div>
-            
-          </div>
-
-        <% end %>
-      </div>
-    <% else %>
-      <div class="col-span-2 sm:col-span-2 md:col-span-3 flex items-center justify-center">
-        <p class="text-gray-700 text-center">掲示板がありません。</p>
-      </div>
-    <% end %>
+     <%= render partial: "posts/post", locals: { posts: @posts } %>
   </div>
 </div>
-
-<script>
-document.addEventListener('turbo:load', function () {
-  var swiper = new Swiper(".mySwiper", {
-    spaceBetween: 30,
-    effect: "fade",
-    pagination: {
-      el: ".swiper-pagination",
-      clickable: true,
-    },
-    navigation: {
-      nextEl: ".swiper-button-next",
-      prevEl: ".swiper-button-prev",
-    },
-  });
-});
-</script>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -1,11 +1,12 @@
-<div class="mx-auto max-w-xl px-4 py-6 md:px-8">
+<div class="mx-auto max-w-xl px-4 py-6 md:px-8 ">
 <!-- 個別カード -->
-<div class="overflow-hidden bg-white-90 px-2 md:px-6 lg:px-8 shadow-md rounded">
+<div class="overflow-hidden pt-4 bg-white-90 px-2 md:px-6 lg:px-8 shadow-md rounded h-fit">
+
   <div class="swiper-container mySwiper">
     <div class="swiper-wrapper">
       <% @post.post_images.each do |image| %>
-        <div class="swiper-slide relative items-center justify-center bg-gray-90"> 
-          <%= image_tag image.url, loading: "lazy", alt: "", class: "object-cover h-full w-full transition duration-200 group-hover:scale-110 mt-3" %>
+        <div class="swiper-slide group relative block h-80 overflow-hidden bg-gray-100 md:h-64"> 
+          <%= image_tag image.url, loading: "lazy", alt: "", class: "absolute inset-0 h-full w-full object-cover object-center transition duration-500 group-hover:scale-110 " %>
         </div>
       <% end %>
       <div class="swiper-pagination"></div>

--- a/app/views/profiles/edit.html.erb
+++ b/app/views/profiles/edit.html.erb
@@ -1,0 +1,24 @@
+<!-- 非同期処理実装予定 -->
+  <div class="mx-auto max-w-screen-2xl px-4 md:px-8">
+    <div class="text-center max-w-2xl mx-auto shadow-md mt-10">
+      <h2 class="mb-4 text-center text-2xl font-bold text-gray-900 md:mb-8 lg:text-3xl">ユーザー編集</h2>
+
+      <%= form_with model: @user, url: profile_path(@user), method: :put do |f| %>
+        <div class="mx-auto max-w-lg rounded-lg border flex flex-col gap-4 p-4 pb-8 md:p-8">
+          <div class="mb-2 inline-block text-md text-gray-800 sm:text-base">
+            <%= f.label :name, "ユーザー名" %>
+            <%= f.text_field :name, class: "w-full border bg-gray-50 px-3 py-2 text-gray-800 outline-none ring-indigo-300 transition duration-100 focus:ring" %>
+          </div>
+
+          <div class="mb-2 inline-block text-md text-gray-800 sm:text-base">
+            <%= f.label :email, "メールアドレス" %>
+            <%= f.email_field :email, class: "w-full border bg-gray-50 px-3 py-2 text-gray-800 outline-none ring-indigo-300 transition duration-100 focus:ring" %>
+          </div>
+
+          <div class="btn w-full min-w-[120px] rounded border text-black bg-gradient-to-r from-[#a48953] to-[#8c7444] hover:from-white hover:to-white hover:text-gold1 hover:border-gold1">
+            <%= f.submit "保存する", class: "block w-full" %>
+          </div>
+        </div>
+      <% end %>
+    </div>
+  </div>

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -1,0 +1,78 @@
+<div class="gradation-image object-contain">
+  <div class="mx-auto max-w-screen-2xl px-4 md:px-8">
+    <div class="text-center max-w-2xl mx-auto shadow-md mt-10">
+       <h2 class="mb-4 text-center text-2xl font-bold text-gray-900 md:mb-8 lg:text-3xl">ユーザー情報</h2>
+
+        <div class="mx-auto max-w-lg rounded-lg border flex flex-col gap-4 p-4 pb-8 md:p-8">
+          <div class="mb-2 inline-block text-md text-gray-800 sm:text-base">
+            <p>ユーザー名</p>
+            <div class="w-full border bg-gray-50 px-3 py-2 text-gray-800 outline-none ring-indigo-300 transition duration-100 focus:ring">
+              <%= current_user.name %>
+            </div>
+          </div>
+         
+          <div class="mb-2 inline-block text-md text-gray-800 sm:text-base">
+            <p>メールアドレス</p>
+            <div class="w-full border bg-gray-50 px-3 py-2 text-gray-800 outline-none ring-indigo-300 transition duration-100 focus:ring">
+              <%= current_user.email %>
+            </div>
+          </div>
+
+          <div class="btn w-full min-w-[120px] rounded border text-black bg-gradient-to-r from-[#a48953] to-[#8c7444] hover:from-white hover:to-white hover:text-gold1 hover:border-gold1">
+            <%= link_to "編集する", edit_profile_path, class: "block w-full"%>
+          </div>
+        </div>
+      </div>
+    </div>
+  
+  <div class="py-1 sm:py-6 lg:py-7 mt-5">
+    <div class="mx-auto max-w-screen-xl px-5 md:px-8">
+      <div class="mb-5 md:mb-10">
+        <h1 class="mb-4 text-center text-2xl font-bold md:mb-6 lg:text-3xl">投稿一覧</h1>
+      </div>
+
+      <div class="px-14 py-2 grid grid-cols-1 sm:grid-cols-2 md:grid-cols-2 lg:grid-cols-3 gap-6 shadow-md">
+        <% if @posts.present? %>
+          <% @posts.each do |post| %>
+            <div class="overflow-hidden bg-white-90 shadow-md rounded">
+              <div class="swiper-container mySwiper">
+                <div class="swiper-wrapper">
+                  <% post.post_images.each do |image| %>
+                    <div class="swiper-slide group relative block h-40 overflow-hidden bg-gray-100 md:h-64">
+                      <%= link_to image_tag(image.url, loading: "lazy", alt: "post images", class: "absolute inset-0 h-full w-full object-cover object-center transition duration-500 group-hover:scale-110 "), post_path(post) %>
+                    </div>
+                  <% end %>
+                  <div class="swiper-pagination"></div>
+                </div>
+              </div>
+
+              <div class="p-1 sm:p-1">
+                <div class="flex items-center">
+                  <h2 class="text-md font-semibold"><%= post.temple_name %></h2>
+                  ｜<span class="text-xs text-gray-700"><%= post.location%></span>
+                </div>
+
+                <p class="text-gray-500 break-words lg:h-12 text-xs mt-1"><%= truncate(post.comment, length: 90) %></p>
+
+                <div class="mt-auto flex items-center items-end justify-between">
+                  <div class="flex items-center gap-2">
+                    <div>
+                      <span class="block text-sm text-indigo-500"><%= post.user.name %></span>
+                    </div>
+                  </div>
+
+                  <span class="px-2 py-1 text-xs text-gray-500"><%= post.created_at.strftime("%Y-%m-%d") %></span>
+                </div>
+              </div>   
+            </div>
+          <% end %>
+        </div>
+        <% else %>
+          <div class="col-span-2 sm:col-span-2 md:col-span-3 flex items-center justify-center">
+            <p class="text-gray-700 text-center">掲示板がありません。</p>
+          </div>
+        <% end %>
+      </div>
+
+  </div>
+</div>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -12,8 +12,9 @@
             <summary class="mr-2">メニュー</summary>
             <ul class="bg-my_white px-1 py-2 rounded-md text-sm top-7 right-1 leading-normal w-48 z-50">
               <% if user_signed_in? %>
-                <li><%= link_to 'みんなの投稿', posts_path %></li>
+                <li><%= link_to '投稿一覧', posts_path %></li>
                 <li><%= link_to '新規投稿', new_post_path %></li>
+                <li><%= link_to 'マイページ', profile_path %></li>
                 <li><%= link_to 'ログアウト', destroy_user_session_path, data: { turbo_method: :delete } %></li>
               <% else %>
                 <li><%= link_to '新規登録', new_user_registration_path %></li>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,6 +17,8 @@ Rails.application.routes.draw do
   root "home#index"
   resources :personality_tests, only: [ :new, :create, :show ]
   resources :posts, only: [ :index, :new, :create, :edit, :show, :edit, :update, :destroy ]
+  resource  :profile, only: [ :show, :edit, :update ]
+
   # resources :posts do
   #  resources :post_images, :only => [:create, :destroy]
   # end


### PR DESCRIPTION
### 概要
 - ユーザーマイページの実装
 - ユーザーマイページにてプロフィールの編集機能の実装

### 変更点
1. `app/views/shared/_header.html.erb` にマイページへのリンクを追加
   - `<li><%= link_to 'マイページ', profile_path %></li>`
2. `app/controllers/profiles_controller.rb`を作成。マイページ関連の動作を制御
3. `app/views/profiles/show.html.erb`、`app/views/profiles/edit.html.erb` を作成。