### PR TITLE
add:閲覧数実装

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,6 +1,6 @@
 class PostsController < ApplicationController
   def index
-    @posts = Post.includes(:user)
+    @posts = Post.includes(:user, :view_counts).all
   end
 
   def new
@@ -19,6 +19,9 @@ class PostsController < ApplicationController
 
   def show
     @post = Post.find(params[:id])
+    unless current_user.view_counts.find_by(user_id: current_user.id, post_id: @post.id)
+      current_user.view_counts.create(post_id: @post.id)
+    end
   end
 
   def edit

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -42,7 +42,7 @@ class Users::RegistrationsController < Devise::RegistrationsController
 
   # If you have extra params to permit, append them to the sanitizer.
   def configure_sign_up_params
-    devise_parameter_sanitizer.permit(:sign_up, keys: [ :name ])
+    devise_parameter_sanitizer.permit(:sign_up, keys: [ :name, :email ])
   end
 
   # If you have extra params to permit, append them to the sanitizer.

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -6,6 +6,7 @@ class Post < ApplicationRecord
 
   mount_uploaders :post_images, PostImageUploader
   belongs_to :user
+  has_many :view_counts, dependent: :destroy
 
   private
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,4 +5,5 @@ class User < ApplicationRecord
          :recoverable, :rememberable, :validatable
   validates :name, presence: true, length: { maximum: 50 }
   has_many :posts, dependent: :destroy
+  has_many :view_counts, dependent: :destroy
 end

--- a/app/models/view_count.rb
+++ b/app/models/view_count.rb
@@ -1,0 +1,4 @@
+class ViewCount < ApplicationRecord
+  belongs_to :user
+  belongs_to :post
+end

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -5,7 +5,7 @@
 
       <%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
         <div class="mx-auto max-w-lg rounded-lg border flex flex-col gap-4 p-4 md:p-8">
-    
+
           <% flash.each do |message_type, message| %>
             <%= content_tag :div, message, class: "message_type text-red-700" %>
           <% end %>
@@ -19,14 +19,14 @@
             <%= f.label :password, class: "mb-2 inline-block text-sm text-gray-800 sm:text-base" %>
             <%= f.password_field :password, autocomplete: "current-password", placeholder: "パスワードを入力" ,class: "w-full rounded border bg-gray-50 px-3 py-2 text-gray-800 outline-none ring-indigo-300 transition duration-100 focus:ring" %>
           </div>
-         
+
           <% if devise_mapping.rememberable? %>
             <div class="field">
               <%= f.check_box :remember_me %>
               <%= f.label :remember_me %>
             </div>
           <% end %>
-          
+
           <div class="actions">
             <%= f.submit "ログイン", class: "btn w-full min-w-[120px] rounded border text-black bg-gradient-to-r from-[#a48953] to-[#8c7444] hover:from-white hover:to-white hover:text-gold1 hover:border-gold1" %>
           </div>

--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -28,7 +28,10 @@
                 </div>
               </div>
 
-              <span class="px-2 py-1 text-xs text-gray-500"><%= post.created_at.strftime("%Y-%m-%d") %></span>
+              <span class="px-2 py-1 text-xs text-gray-500">
+                <i class="fa-regular fa-eye"><%= post.view_counts.count %></i> 
+                <%= post.created_at.strftime("%Y-%m-%d") %>
+              </span>
             </div>
           </div>
         </div>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -1,47 +1,46 @@
 <div class="mx-auto max-w-xl px-4 py-6 md:px-8 ">
-<!-- 個別カード -->
-<div class="overflow-hidden pt-4 bg-white-90 px-2 md:px-6 lg:px-8 shadow-md rounded h-fit">
-
-  <div class="swiper-container mySwiper">
-    <div class="swiper-wrapper">
-      <% @post.post_images.each do |image| %>
-        <div class="swiper-slide group relative block h-80 overflow-hidden bg-gray-100 md:h-64"> 
-          <%= image_tag image.url, loading: "lazy", alt: "", class: "absolute inset-0 h-full w-full object-cover object-center transition duration-500 group-hover:scale-110 " %>
-        </div>
-      <% end %>
+  <div class="overflow-hidden pt-4 bg-white-90 px-2 md:px-6 lg:px-8 shadow-md rounded h-fit">
+    <div class="swiper-container mySwiper">
+      <div class="swiper-wrapper">
+        <% @post.post_images.each do |image| %>
+          <div class="swiper-slide group relative block h-80 overflow-hidden bg-gray-100 md:h-64"> 
+            <%= image_tag image.url, loading: "lazy", alt: "", class: "absolute inset-0 h-full w-full object-cover object-center transition duration-500 group-hover:scale-110 " %>
+          </div>
+        <% end %>
       <div class="swiper-pagination"></div>
     </div>
-  </div>  
+  </div>
 
   <div class="sm:p-3 pl-4 flex-grow">
     <div class="flex items-center mt-3">
-        <h2 class="text-xl font-semibold"><%= @post.temple_name %></h2>
-        ｜<span class="text-xs text-gray-700"><%= @post.location %></span>
+      <h2 class="text-xl font-semibold"><%= @post.temple_name %></h2>
+      ｜<span class="text-xs text-gray-700"><%= @post.location %></span>
     </div>
-   
-
     <p class="text-gray-500 mt-2 break-words"><%=@post.comment%></p>
-
     <div class="mt-auto flex items-end justify-between mb-2">
       <div class="flex items-center">
         <div>
           <span class="block text-indigo-500"><%= @post.user.name %></span>
         </div>
       </div>
-
-      <% if current_user == @post.user %>
-      <span class="px-2 py-2 text-sm text-gray-500">
-        <%= link_to edit_post_path(@post), id: "button-edit-#{@post.id}" do %>
-          <i class="fa-solid fa-pen-to-square mr-2 fa-xl"></i>
+        <% if current_user == @post.user %>
+          <span class="px-2 py-2 text-sm text-gray-500">
+            <%= link_to edit_post_path(@post), id: "button-edit-#{@post.id}" do %>
+              <i class="fa-solid fa-pen-to-square mr-2 fa-xl"></i>
+            <% end %>
+            <%= link_to post_path(@post), id: "button-delete-#{@post.id}", data: { turbo_method: :delete, turbo_confirm: "削除してもいいですか？" } do %>
+              <i class="fa-regular fa-trash-can mr-2 fa-xl"></i>
+            <% end %>
+            <i class="fa-regular fa-eye"><%= @post.view_counts.count %></i>
+            <%= @post.created_at.strftime("%Y-%m-%d") %>
+          </span>
+        <% else %>
+          <span class="px-2 py-2 text-sm text-gray-500">
+            <i class="fa-regular fa-eye"><%= @post.view_counts.count %></i>
+            <%= @post.created_at.strftime("%Y-%m-%d") %>
+          </span>
         <% end %>
-        <%= link_to post_path(@post), id: "button-delete-#{@post.id}", data: { turbo_method: :delete, turbo_confirm: "削除してもいいですか？" } do %>
-          <i class="fa-regular fa-trash-can mr-2 fa-xl"></i>
-        <% end %>
-        <%= @post.created_at.strftime("%Y-%m-%d") %>
-      </span>
-      <% end %>
+      </div>
     </div>
   </div>
-  
-</div>
 </div>

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -60,8 +60,8 @@
                       <span class="block text-sm text-indigo-500"><%= post.user.name %></span>
                     </div>
                   </div>
-
-                  <span class="px-2 py-1 text-xs text-gray-500"><%= post.created_at.strftime("%Y-%m-%d") %></span>
+                  
+                  <span class="px-2 py-1 text-xs text-gray-500"><i class="fa-regular fa-eye"><%= post.view_counts.count %></i><%= post.created_at.strftime("%Y-%m-%d") %></span>
                 </div>
               </div>   
             </div>

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -46,7 +46,7 @@ Devise.setup do |config|
   # session. If you need permissions, you should implement that in a before filter.
   # You can also supply a hash where the value is a boolean determining whether
   # or not authentication should be aborted when the value is not present.
-  # config.authentication_keys = [:email]
+  config.authentication_keys = [:name]
 
   # Configure parameters from the request object used for authentication. Each entry
   # given should be a request method and it will automatically be passed to the
@@ -244,7 +244,7 @@ Devise.setup do |config|
   # Turn scoped views on. Before rendering "sessions/new", it will first check for
   # "users/sessions/new". It's turned off by default because it's slower if you
   # are using only default views.
-  # config.scoped_views = false
+  config.scoped_views = true
 
   # Configure the default scope given to Warden. By default it's the first
   # devise role declared in your routes (usually :user).

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -46,7 +46,7 @@ Devise.setup do |config|
   # session. If you need permissions, you should implement that in a before filter.
   # You can also supply a hash where the value is a boolean determining whether
   # or not authentication should be aborted when the value is not present.
-  config.authentication_keys = [:name]
+  config.authentication_keys = [ :name ]
 
   # Configure parameters from the request object used for authentication. Each entry
   # given should be a request method and it will automatically be passed to the

--- a/db/migrate/20241226140935_create_view_counts.rb
+++ b/db/migrate/20241226140935_create_view_counts.rb
@@ -1,0 +1,10 @@
+class CreateViewCounts < ActiveRecord::Migration[7.2]
+  def change
+    create_table :view_counts do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :post, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_12_24_091412) do
+ActiveRecord::Schema[7.2].define(version: 2024_12_26_140935) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -65,6 +65,17 @@ ActiveRecord::Schema[7.2].define(version: 2024_12_24_091412) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  create_table "view_counts", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "post_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["post_id"], name: "index_view_counts_on_post_id"
+    t.index ["user_id"], name: "index_view_counts_on_user_id"
+  end
+
   add_foreign_key "posts", "users"
   add_foreign_key "score_mappings", "questions"
+  add_foreign_key "view_counts", "posts"
+  add_foreign_key "view_counts", "users"
 end

--- a/test/fixtures/view_counts.yml
+++ b/test/fixtures/view_counts.yml
@@ -1,0 +1,9 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  user: one
+  post: one
+
+two:
+  user: two
+  post: two

--- a/test/models/view_count_test.rb
+++ b/test/models/view_count_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class ViewCountTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
### 概要
 - 閲覧数カウント機能の追加
 - Post、Uesrと１対NになるViewCountモデルを作成
 - 掲示板詳細に訪れた数をカウント
### 変更点
1. `post`コントローラーにおいて、現在ログインしているユーザーの閲覧記録が存在しない場合、閲覧記録を作成
```
  def show
    @post = Post.find(params[:id])
    unless current_user.view_counts.find_by(user_id: current_user.id, post_id: @post.id)
      current_user.view_counts.create(post_id: @post.id)
    end
  end
```