### PR TITLE
fix:編集画面の調整

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -68,7 +68,7 @@ group :development, :test do
   gem "debug", platforms: %i[ mri windows ], require: "debug/prelude"
 
   # Static analysis for security vulnerabilities [https://brakemanscanner.org/]
-  gem "brakeman", require: false
+  gem "brakeman", "7.0.0", require: false
 
   # Omakase Ruby styling [https://github.com/rails/rubocop-rails-omakase/]
   gem "rubocop-rails-omakase", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -430,7 +430,7 @@ PLATFORMS
 
 DEPENDENCIES
   bootsnap
-  brakeman
+  brakeman (= 7.0.0)
   capybara
   carrierwave (~> 3.0)
   cssbundling-rails

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,6 +1,6 @@
 class PostsController < ApplicationController
   before_action :set_post, only: %i[ edit update destroy ]
-  
+
   def index
     @q = Post.ransack(params[:q])
     @posts = @q.result(distinct: false).includes(:user, :view_counts).order(created_at: :desc).all.page(params[:page])

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,4 +1,6 @@
 class PostsController < ApplicationController
+  before_action :set_post, only: %i[ edit update destroy ]
+  
   def index
     @q = Post.ransack(params[:q])
     @posts = @q.result(distinct: false).includes(:user, :view_counts).order(created_at: :desc).all.page(params[:page])
@@ -10,7 +12,6 @@ class PostsController < ApplicationController
 
   def create
     @post = current_user.posts.build(post_params)
-    logger.debug "Params: #{params[:post][:map_attributes]}"
     if @post.save
       if params[:post][:map_attributes].present?
         latitude = params[:post][:map_attributes][:latitude]
@@ -34,9 +35,7 @@ class PostsController < ApplicationController
 
   def show
     @post = Post.find(params[:id])
-    @map = @post.map
-    gon.latitude = @map.latitude
-    gon.longitude = @map.longitude
+    set_map_data
 
     unless current_user.view_counts.find_by(user_id: current_user.id, post_id: @post.id)
       current_user.view_counts.create(post_id: @post.id)
@@ -44,11 +43,10 @@ class PostsController < ApplicationController
   end
 
   def edit
-    @post = current_user.posts.find(params[:id])
+    set_map_data
   end
 
   def update
-    @post = current_user.posts.find(params[:id])
     if @post.update(post_params)
       redirect_to post_path(@post), success: "掲示板を更新しました。"
     else
@@ -58,12 +56,21 @@ class PostsController < ApplicationController
   end
 
   def destroy
-    post = current_user.posts.find(params[:id])
-    post.destroy!
+    @post.destroy!
     redirect_to posts_path, success: "削除しました。"
   end
 
   private
+
+  def set_post
+    @post = current_user.posts.find(params[:id])
+  end
+
+  def set_map_data
+    @map = @post.map
+    gon.latitude = @map.latitude
+    gon.longitude = @map.longitude
+  end
 
   def post_params
     params.require(:post).permit(

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1,7 +1,7 @@
 class Post < ApplicationRecord
   validates :temple_name, presence: true, length: { maximum: 20 }
   validates :comment, presence: true, length: { maximum: 255 }
-  validates :post_images, presence: { message: I18n.t('activerecord.errors.messages.post_images_blank') }
+  validates :post_images, presence: { message: I18n.t("activerecord.errors.messages.post_images_blank") }
   validate :validate_image_coutn
 
   mount_uploaders :post_images, PostImageUploader

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1,7 +1,7 @@
 class Post < ApplicationRecord
   validates :temple_name, presence: true, length: { maximum: 20 }
   validates :comment, presence: true, length: { maximum: 255 }
-  validates :post_images, presence: true
+  validates :post_images, presence: { message: I18n.t('activerecord.errors.messages.post_images_blank') }
   validate :validate_image_coutn
 
   mount_uploaders :post_images, PostImageUploader
@@ -21,7 +21,7 @@ class Post < ApplicationRecord
   private
 
   def validate_image_coutn
-    if post_images.count >= 3
+    if post_images.count > 3
       errors.add(:post_images, "は3枚以下にしてください。")
     end
   end

--- a/app/views/posts/_form_post.html.erb
+++ b/app/views/posts/_form_post.html.erb
@@ -5,13 +5,13 @@
   </div>
 
   <div class="input-field">
-    <%= f.fields_for :map, @post.build_map, id: 'map-fields' do |map| %>
+    <%= f.fields_for :map, @post.map || @post.build_map, id: 'map-fields' do |map| %>
       <%= map.label :address, "場所", class: "mb-2 inline-block text-sm text-gray-800 sm:text-base" %>
       <%= map.text_field :address, id: "address", class: "form-control w-full border bg-gray-50 px-3 py-2 text-gray-800 outline-none ring-indigo-300 transition duration-100 focus:ring" %>
 
       <a class="btn m-4" onclick="codeAddress()">地名で検索</a>
 
-      <div id="map" style="width: 100%; height: 500px;"></div>
+      <div id="<%= map_id %>" style="width: 100%; height: 500px;"></div>
 
       <%= map.hidden_field :latitude, id: "post_map_latitude" %>
       <%= map.hidden_field :longitude, id: "post_map_longitude" %>

--- a/app/views/posts/edit.html.erb
+++ b/app/views/posts/edit.html.erb
@@ -4,14 +4,14 @@
       <%= render 'shared/error_messages', object: @post %>
     </div>
   <div class="mx-auto max-w-md rounded-lg border flex flex-col gap-4 md:p-8">
-    <%= render 'form_post' %>
+    <%= render 'form_post', map_id: "edit-map-#{@post.id}", locals: { post: @post, map: @map } %>
   </div>
 </div>
 
 
 <script 
   type="text/javascript" 
-  src="https://maps.googleapis.com/maps/api/js?key=<%= ENV['GOOGLE_MAP_API'] %>&callback=initMap" 
+  src="https://maps.googleapis.com/maps/api/js?key=<%= ENV['GOOGLE_MAP_API'] %>&callback=initializeMap" 
   async
   defer
   >
@@ -19,55 +19,68 @@
 
 <script>
   let map;
-  let map_lat
-  let map_lng
-  let marker
-  
-  function initMap() {
-    // 中心地の座標を指定
-    const myLatLng = { lat: 35.68090045006303, lng: 139.76690798417752 };
-  
+  let map_lat;
+  let map_lng;
+  let marker;
+
+  function initializeMap() {
+    // もしユーザーの保存した座標があれば、それを使う
+    const myLatLng = { 
+      lat: <%= @post.map.latitude || 35.68090045006303 %>, 
+      lng: <%= @post.map.longitude || 139.76690798417752 %> 
+    };
+
     // 地図を初期化
-    map = new google.maps.Map(document.getElementById('map'), {
+    map = new google.maps.Map(document.getElementById('edit-map-<%= @post.id %>'), {
       center: myLatLng,
-      zoom: 10
+      zoom: 12
     });
 
     // マーカーの初期化
     marker = new google.maps.Marker();
     map_lat = document.getElementById('post_map_latitude');
-    map_lng = document.getElementById('post_map_longitude'); // IDを取得
-  
+    map_lng = document.getElementById('post_map_longitude');
+
+    // 地図上でクリックした位置にマーカーを設定
     google.maps.event.addListener(map, 'click', mylistener);
+
     function mylistener(event) {
       marker.setPosition(new google.maps.LatLng(event.latLng.lat(), event.latLng.lng()));
       marker.setMap(map);
-      map_lat.value = event.latLng.lat(); // 緯度を設定
-      map_lng.value = event.latLng.lng(); // 経度を設定
+      map_lat.value = event.latLng.lat();  // 緯度を設定
+      map_lng.value = event.latLng.lng();  // 経度を設定
+    }
+
+    // もし保存された位置があれば、マーカーをその位置に移動
+    if (myLatLng.lat && myLatLng.lng) {
+      marker.setPosition(new google.maps.LatLng(myLatLng.lat, myLatLng.lng));
+      marker.setMap(map);
+      map_lat.value = myLatLng.lat;
+      map_lng.value = myLatLng.lng;
     }
   }
 
-  function codeAddress(){
-    geocoder = new google.maps.Geocoder()
+  // 地名で位置を検索する関数
+  function codeAddress() {
+    geocoder = new google.maps.Geocoder();
     let inputAddress = document.getElementById('address').value;
 
-    // 地名をもとに位置を取得
-    geocoder.geocode( { 
+    geocoder.geocode({ 
       'address': inputAddress,
       'region': 'jp'
     }, function(results, status) {
       if (status == 'OK') {
-      map.setCenter(results[0].geometry.location);
-      map_result = results[0].geometry.location;
-      map_lat.value = map_result.lat();
-      map_lng.value = map_result.lng();
-      marker.setPosition(new google.maps.LatLng(map_result.lat(), map_result.lng()));
-      marker.setMap(map);
-      console.log(map_lat.value,map_lng.value);
-    } else {
-      alert('該当する結果がありませんでした');
-      initMap();
-    }
-  });   
-}
+        map.setCenter(results[0].geometry.location);
+        map_result = results[0].geometry.location;
+        map_lat.value = map_result.lat();
+        map_lng.value = map_result.lng();
+        marker.setPosition(new google.maps.LatLng(map_result.lat(), map_result.lng()));
+        marker.setMap(map);
+      } else {
+        alert('該当する結果がありませんでした');
+        initMap();
+      }
+    });
+  }
 </script>
+

--- a/app/views/posts/new.html.erb
+++ b/app/views/posts/new.html.erb
@@ -4,7 +4,7 @@
       <%= render 'shared/error_messages', object: @post %>
     </div>
   <div class="mx-auto max-w-md rounded-lg border flex flex-col gap-4 md:p-8">
-    <%= render 'form_post' %>
+    <%= render 'form_post', map_id: "new-map" %>
   </div>
 </div>
 
@@ -28,9 +28,9 @@
     const myLatLng = { lat: 35.68090045006303, lng: 139.76690798417752 };
   
     // 地図を初期化
-    map = new google.maps.Map(document.getElementById('map'), {
+    map = new google.maps.Map(document.getElementById('new-map'), {
       center: myLatLng,
-      zoom: 10
+      zoom: 12
     });
 
     // マーカーの初期化

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -25,7 +25,7 @@
       </div>
         <% if current_user == @post.user %>
           <span class="px-2 py-2 text-sm text-gray-500">
-            <%= link_to edit_post_path(@post), id: "button-edit-#{@post.id}" do %>
+            <%= link_to edit_post_path(@post), id: "button-edit-#{@post.id}", data: { turbo: false }  do %>
               <i class="fa-solid fa-pen-to-square mr-2 fa-xl"></i>
             <% end %>
             <%= link_to post_path(@post), id: "button-delete-#{@post.id}", data: { turbo_method: :delete, turbo_confirm: "削除してもいいですか？" } do %>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -17,7 +17,7 @@
                 <li><%= link_to 'マイページ', profile_path %></li>
                 <li><%= link_to 'ログアウト', destroy_user_session_path, data: { turbo_method: :delete } %></li>
               <% else %>
-                <li><%= link_to '新規登録', new_user_registration_path %></li>
+                <li><%= link_to '新規登録', new_user_registration_path, data: { turbo: false }  %></li>
                 <li><%= link_to 'ログイン', new_user_session_path %></li>
               <% end %>
               <hr class="my-2 h-0.5 border-t-0 bg-neutral-100" />

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -5,7 +5,6 @@ ja:
     attributes:
       post:
         temple_name: "寺院・史跡名"
-        location: "場所"
         comment: "コメント"
         post_images: "画像"
       map:
@@ -13,6 +12,7 @@ ja:
     errors:
       messages:
         blank: "を入力してください"
+        post_images_blank: "を選択してください"
   views:
       pagination:
         previous: "前へ"


### PR DESCRIPTION
### 概要
 - 投稿編集画面のマップにおいて、ユーザー設定の位置情報が初期値として表示されるよう修正

### 詳細
 - `<div id="<%= map_id %>" style="width: 100%; height: 500px;"></div>`
 - `edit.html.erb`
    - `<%= render 'form_post', map_id: "edit-map-#{@post.id}", locals: { post: @post, map: @map } %>`に変更
 - `new.html.erb`
    - ` <%= render 'form_post', map_id: "new-map" %>`に変更 
 