### PR TITLE
微修正

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -78,7 +78,7 @@ Rails.application.configure do
   # caching is enabled.
   config.action_mailer.perform_caching = false
 
-  config.action_mailer.default_url_options = { host: "https://monkpersonalitytestapp.onrender.com" }
+  config.action_mailer.default_url_options = { host: "monkpersonalitytestapp.onrender.com", protocol: "https"  }
   config.action_mailer.delivery_method = :smtp
   config.action_mailer.smtp_settings = {
     address:              "smtp.gmail.com",


### PR DESCRIPTION
### 概要
 - `config.action_mailer.default_url_options = { host: "monkpersonalitytestapp.onrender.com", protocol: "https"  }`host、protocolに分離