### PR TITLE
add:ユーザーマイマップ

### DIFF
--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -26,7 +26,7 @@ class ProfilesController < ApplicationController
       }
     end
   end
-  
+
   private
 
   def set_user

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -16,8 +16,17 @@ class ProfilesController < ApplicationController
 
   def show
     @posts = current_user.posts
+    @locations = Map.joins(:post).where(posts: { user_id: current_user.id }).select("maps.*, posts.id as post_id")
+    gon.locations = @locations.map do |location|
+      {
+        latitude: location.latitude,
+        longitude: location.longitude,
+        address: location.address,
+        link: post_path(location.post_id)
+      }
+    end
   end
-
+  
   private
 
   def set_user

--- a/app/views/posts/_form_post.html.erb
+++ b/app/views/posts/_form_post.html.erb
@@ -11,7 +11,7 @@
 
       <a class="btn m-4" onclick="codeAddress()">地名で検索</a>
 
-      <div id="<%= map_id %>" style="width: 100%; height: 500px;"></div>
+      <div id="<%= map_id %>" class="w-full h-[400px] mb-5"></div>
 
       <%= map.hidden_field :latitude, id: "post_map_latitude" %>
       <%= map.hidden_field :longitude, id: "post_map_longitude" %>

--- a/app/views/posts/edit.html.erb
+++ b/app/views/posts/edit.html.erb
@@ -1,4 +1,4 @@
-<div class="text-center max-w-2xl mx-auto shadow-md mt-10 sm:px-4">
+<div class="text-center max-w-2xl mx-auto shadow-md mt-10 sm:px-4 pb-8">
   <h1 class="mb-4 text-center text-2xl font-bold text-gray-900 md:mb-8 py-2 lg:text-3xl">編集</h1>
     <div class="pb-4 text-red-700">
       <%= render 'shared/error_messages', object: @post %>

--- a/app/views/posts/new.html.erb
+++ b/app/views/posts/new.html.erb
@@ -1,4 +1,4 @@
-<div class="text-center max-w-2xl mx-auto shadow-md mt-10 sm:px-4">
+<div class="text-center max-w-2xl mx-auto shadow-md mt-10 sm:px-4 pb-8">
   <h1 class="mb-4 text-center text-2xl font-bold text-gray-900 md:mb-8 py-2 lg:text-3xl">新規投稿</h1>
     <div class="pb-4 text-red-700">
       <%= render 'shared/error_messages', object: @post %>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -42,7 +42,7 @@
         <% end %>
       </div>
     </div>
-    <div id="map" style="width: 100%; height: 400px;"></div>
+    <div id="map" class="w-full h-[400px] mb-8"></div>
   </div>
 </div>
 

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -1,6 +1,6 @@
 <div class="gradation-image object-contain">
   <div class="mx-auto max-w-screen-2xl px-4 md:px-8">
-    <div class="text-center max-w-2xl mx-auto shadow-md mt-10">
+    <div class="text-center max-w-2xl mx-auto shadow-md mt-10 pb-8">
        <h2 class="mb-4 text-center text-2xl font-bold text-gray-900 md:mb-8 lg:text-3xl">ユーザー情報</h2>
 
         <div class="mx-auto max-w-lg rounded-lg border flex flex-col gap-4 p-4 pb-8 md:p-8">
@@ -24,9 +24,18 @@
         </div>
       </div>
     </div>
+
   
+    <div class="mb-5 mt-8 md:mb-10">
+    <h1 class="mb-4 text-center text-2xl font-bold md:mb-6 lg:text-3xl">マイマップ</h1>
+  </div>
+    <div class="flex justify-center mt-5">
+    <div id="profiles-map" class="w-full max-w-3xl" style="height: 500px;"></div>
+  </div>
+
   <div class="py-1 sm:py-6 lg:py-7 mt-5">
     <div class="mx-auto max-w-screen-xl px-5 md:px-8">
+
       <div class="mb-5 md:mb-10">
         <h1 class="mb-4 text-center text-2xl font-bold md:mb-6 lg:text-3xl">投稿一覧</h1>
       </div>
@@ -73,6 +82,49 @@
           </div>
         <% end %>
       </div>
-
   </div>
 </div>
+
+<script 
+  type="text/javascript" 
+  src="https://maps.googleapis.com/maps/api/js?key=<%= ENV['GOOGLE_MAP_API'] %>&callback=profilesInitMap" 
+  async
+  defer
+></script>
+
+<script>
+  function profilesInitMap() {
+    // 記事未作成時の初期位置
+    const myLatLng = { lat: 35.68090045006303, lng: 139.76690798417752 };
+
+    // 地図の初期位置
+    const initialPosition = gon?.locations?.length > 0
+      ? { lat: gon.locations[0].latitude, lng: gon.locations[0].longitude }
+      : myLatLng
+
+    // 地図を作成
+    const map = new google.maps.Map(document.getElementById("profiles-map"), {
+      center: initialPosition,
+      zoom: 9,
+    });
+
+    if (gon?.locations?.length > 0) {
+      gon.locations.forEach((location) => {
+        const marker = new google.maps.Marker({
+          position: { lat: location.latitude, lng: location.longitude },
+          map: map,
+          title: location.address,
+        });
+
+        marker.addListener("click", function(){
+          window.location.href = location.link;
+        });
+      });
+    } else {
+      new google.maps.Marker({
+        position: myLatLng,
+        map: map,
+      });
+    }
+  }
+</script>

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -59,7 +59,7 @@ Rails.application.configure do
     .tap  { |logger| logger.formatter = ::Logger::Formatter.new }
     .then { |logger| ActiveSupport::TaggedLogging.new(logger) }
 
-  config.action_mailer.logger = ActiveSupport::Logger.new(STDOUT)  
+  config.action_mailer.logger = ActiveSupport::Logger.new(STDOUT)
 
   config.action_mailer.logger.level = :debug
 


### PR DESCRIPTION
### 概要
 - ユーザープロフィール画面において投稿記事と結びついたマップを表示
 
### 詳細
 - `profiles_controller.rb` においてユーザーが登録した位置情報を配列で取得
```
  def show
    @posts = current_user.posts
    @locations = Map.joins(:post).where(posts: { user_id: current_user.id }).select("maps.*, posts.id as post_id")
    gon.locations = @locations.map do |location|
      {
        latitude: location.latitude,
        longitude: location.longitude,
        address: location.address,
        link: post_path(location.post_id)
      }
    end
  end
```
 - `app/views/profiles/show.html.erb`において位置情報が存在していれば表示。デフォルトでは`myLatLng`を表示
```
    const myLatLng = { lat: 35.68090045006303, lng: 139.76690798417752 };
    // 地図の初期位置
    const initialPosition = gon?.locations?.length > 0
      ? { lat: gon.locations[0].latitude, lng: gon.locations[0].longitude }
      : myLatLng
    // 地図を作成
    const map = new google.maps.Map(document.getElementById("profiles-map"), {
      center: initialPosition,
      zoom: 9,
    });
```