### PR TITLE
fix:ピン画像パスの修正

### DIFF
--- a/app/views/posts/_form_post.html.erb
+++ b/app/views/posts/_form_post.html.erb
@@ -13,7 +13,7 @@
             <div class="w-1/4 p-2">
               <%= f.radio_button :marker_image, "/assets/marker_image/#{icon}", id: "icon_#{index}", class: "hidden peer" %>
               <%= label_tag "icon_#{index}", class: "cursor-pointer border-2 border-gray-300 rounded-md hover:border-indigo-500 peer-checked:border-indigo-500 block" do %>
-                <%= image_tag("marker_image/#{icon}", alt: "アイコン#{index + 1}", class: "w-16 h-16 object-cover mx-auto") %>
+                <%= image_tag(asset_path("marker_image/#{icon}"), alt: "アイコン#{index + 1}", class: "w-16 h-16 object-cover mx-auto") %>
               <% end %>
             </div>
           <% end %>


### PR DESCRIPTION
### 概要
 - `<%= image_tag(asset_path("marker_image/#{icon}"), alt: "アイコン#{index + 1}", class: "w-16 h-16 object-cover mx-auto") %>` において`asset_path`を追加。