### PR TITLE
逆ジオコーディング実装

### DIFF
--- a/app/views/posts/_form_post.html.erb
+++ b/app/views/posts/_form_post.html.erb
@@ -21,7 +21,8 @@
 
   <div class="input-field mt-4">
     <%= f.fields_for :map, @post.map || @post.build_map, id: 'map-fields' do |map| %>
-      <%= map.label :address, "場所", class: "mb-2 inline-block text-sm text-gray-800 sm:text-base" %>
+      <%= map.label :address, "場所", class: "inline-block text-gray-800 sm:text-base" %>
+      <p class="mb-2 text-sm">(マップにピンを設置すると住所が表示されます)</p>
       <%= map.text_field :address, id: "address", class: "form-control w-full border bg-gray-50 px-3 py-2 text-gray-800 outline-none ring-indigo-300 transition duration-100 focus:ring" %>
 
       <a class="btn m-4" onclick="codeAddress()">地名で検索</a>

--- a/app/views/posts/edit.html.erb
+++ b/app/views/posts/edit.html.erb
@@ -31,7 +31,7 @@
     if (marker) {
       marker.setIcon({
         url: imageUrl,
-        scaledSize: new google.maps.Size(33, 33) // 必要に応じて画像サイズを調整
+        scaledSize: new google.maps.Size(60, 60)
       });
     }
   }
@@ -57,7 +57,7 @@
       map: map,
       icon: {
         url: initialImageUrl,
-        scaledSize: new google.maps.Size(33, 33)
+        scaledSize: new google.maps.Size(60, 60)
       }
     });
 
@@ -71,14 +71,18 @@
     });
 
     // 地図上でクリックした位置にマーカーを設定
-    google.maps.event.addListener(map, 'click', mylistener);
-
-    function mylistener(event) {
-      marker.setPosition(new google.maps.LatLng(event.latLng.lat(), event.latLng.lng()));
+    google.maps.event.addListener(map, 'click', function(event) {
+      const lat = event.latLng.lat();
+      const lng = event.latLng.lng();
+      
+      marker.setPosition(event.latLng);
       marker.setMap(map);
-      map_lat.value = event.latLng.lat();  // 緯度を設定
-      map_lng.value = event.latLng.lng();  // 経度を設定
-    }
+      map_lat.value = lat;  // 緯度を設定
+      map_lng.value = lng;  // 経度を設定
+
+      // 逆ジオコーディングで住所を取得
+      geocodeLatLng(lat, lng);
+    });
 
     // もし保存された位置があれば、マーカーをその位置に移動
     if (myLatLng.lat && myLatLng.lng) {
@@ -86,12 +90,14 @@
       marker.setMap(map);
       map_lat.value = myLatLng.lat;
       map_lng.value = myLatLng.lng;
+
+
+      geocodeLatLng(myLatLng.lat, myLatLng.lng);
     }
   }
 
-  // 地名で位置を検索する関数
   function codeAddress() {
-    geocoder = new google.maps.Geocoder();
+    const geocoder = new google.maps.Geocoder();
     let inputAddress = document.getElementById('address').value;
 
     geocoder.geocode({ 
@@ -100,15 +106,30 @@
     }, function(results, status) {
       if (status == 'OK') {
         map.setCenter(results[0].geometry.location);
-        map_result = results[0].geometry.location;
+        const map_result = results[0].geometry.location;
         map_lat.value = map_result.lat();
         map_lng.value = map_result.lng();
         marker.setPosition(new google.maps.LatLng(map_result.lat(), map_result.lng()));
         marker.setMap(map);
       } else {
         alert('該当する結果がありませんでした');
-        initMap();
       }
     });
+  }
+
+  // 逆ジオコーディング
+  function geocodeLatLng(lat, lng) {
+    const geocoder = new google.maps.Geocoder();
+    const latlng = { lat: lat, lng: lng };
+
+    geocoder.geocode({ location: latlng })
+      .then((response) => {
+        if (response.results[0]) {
+          let address = response.results[0].formatted_address;
+          address = address.replace(/^日本、?|\s?〒\d{3}-\d{4}/g, '').trim();
+          document.getElementById("address").value = address;
+        }
+      })
+      .catch((error) => console.error(error));
   }
 </script>

--- a/app/views/posts/new.html.erb
+++ b/app/views/posts/new.html.erb
@@ -69,6 +69,8 @@ function initMap() {
     map_lng.value = lng; // 隠しフィールドに値を設定
 
     newMarker(lat, lng);
+
+    geocodeLatLng(lat, lng);
   });
 }
 
@@ -98,5 +100,26 @@ function codeAddress() {
     }
   );
 }
+
+function geocodeLatLng(lat, lng) {
+  const geocoder = new google.maps.Geocoder();
+  const latlng = { lat: lat, lng: lng };
+
+  // 逆ジオコーディング処理
+  geocoder.geocode({ location: latlng })
+    .then((response) => {
+      if (response.results[0]) {
+        // 住所を取得
+        let address = response.results[0].formatted_address;
+
+        address = address.replace(/^日本、?|\s?〒\d{3}-\d{4}/g, '').trim();
+
+        document.getElementById("address").value = address; // 住所をフォームにセット
+      }
+    })
+  .catch((error) => console.error(error));
+}
+
+window.initMap = initMap;
 
 </script>

--- a/app/views/posts/new.html.erb
+++ b/app/views/posts/new.html.erb
@@ -109,12 +109,11 @@ function geocodeLatLng(lat, lng) {
   geocoder.geocode({ location: latlng })
     .then((response) => {
       if (response.results[0]) {
-        // 住所を取得
-        let address = response.results[0].formatted_address;
-
+        let address = response.results[0].formatted_address; // 住所を取得
         address = address.replace(/^日本、?|\s?〒\d{3}-\d{4}/g, '').trim();
-
         document.getElementById("address").value = address; // 住所をフォームにセット
+      } else {
+        console.log("住所を取得できませんでした。")
       }
     })
   .catch((error) => console.error(error));

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -1,5 +1,5 @@
 <div class="mx-auto max-w-xl px-4 py-6 md:px-8 ">
-  <div class="pt-4 bg-white-90 px-2 md:px-6 lg:px-8 shadow-md rounded ">
+  <div class="pt-4 pb-4 bg-white-90 px-2 md:px-6 lg:px-8 shadow-md rounded ">
     <div class="swiper mySwiper">
       <div class="swiper-wrapper">
         <% @post.post_images.each do |image| %>
@@ -42,7 +42,7 @@
         <% end %>
       </div>
     </div>
-    <div id="map" class="w-full h-[400px] mb-5"></div>
+      <div id="map" class="w-full h-[400px]"></div>
   </div>
 </div>
 

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -32,7 +32,7 @@
 
               <div class="p-1 sm:p-1">
                 <div class="flex items-center">
-                  <h2 class="text-md font-semibold"><%= post.temple_name %></h2>
+                  <h2 class="text-md font-semibold"><%= link_to post.temple_name, post_path(post) %></h2>
                   ｜<span class="text-xs text-gray-700"><%= post.map.address%></span>
                 </div>
 


### PR DESCRIPTION
### 概要
 - ユーザーが設置したピンから住所を取得できるように実装

### 詳細
 - `new.html.erb` , `edit.html.erb` に逆ジオコーディングのロジックを追加。`(lat, lng)`で位置を取得し、それをもとに住所を表示
 - 正規表現を活用し不要な郵便番号を削除
```
function geocodeLatLng(lat, lng) {
  const geocoder = new google.maps.Geocoder();
  const latlng = { lat: lat, lng: lng };

  // 逆ジオコーディング処理
  geocoder.geocode({ location: latlng })
    .then((response) => {
      if (response.results[0]) {
        let address = response.results[0].formatted_address; // 住所を取得
        address = address.replace(/^日本、?|\s?〒\d{3}-\d{4}/g, '').trim();
        document.getElementById("address").value = address; // 住所をフォームにセット
      } else {
        console.log("住所を取得できませんでした。")
      }
    })
  .catch((error) => console.error(error));
}

window.initMap = initMap;

```