### PR TITLE
掲示板ソート機能実装

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -4,17 +4,18 @@ class PostsController < ApplicationController
   def index
     @q = Post.joins(:map).ransack(params[:q] || {})
     @posts = @q.result(distinct: false).includes(:user, :view_counts).order(created_at: :desc).page(params[:page])
-    # 全ユーザーのマップ情報を取得
-    @locations = Map.joins(:post).where(posts: { id: @posts.pluck(:id) })
-    gon.locations = @locations.map do |location|
-      {
-        latitude: location.latitude,
-        longitude: location.longitude,
-        address: location.address,
-        marker_image: location.marker_image,
-        link: post_path(location.post_id)
-      }
+    @no_results = @posts.empty?
+    
+    if params[:latest]
+        @posts = Post.latest
+      elsif params[:old]
+        @posts = Post.old
+      else
+        @posts = Post.all
     end
+
+    # 全ユーザーのマップ情報を取得
+    gon.locations = Map.locations_posts(@posts)
   end
 
   def new

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -5,13 +5,13 @@ class PostsController < ApplicationController
     @q = Post.joins(:map).ransack(params[:q] || {})
     @posts = @q.result(distinct: false).includes(:user, :view_counts).order(created_at: :desc).page(params[:page])
     @no_results = @posts.empty?
-    
+
     if params[:latest]
-        @posts = Post.latest
-      elsif params[:old]
-        @posts = Post.old
-      else
-        @posts = Post.all
+      @posts = Post.latest
+    elsif params[:old]
+      @posts = Post.old
+    else
+      @posts = Post.all
     end
 
     # 全ユーザーのマップ情報を取得

--- a/app/models/map.rb
+++ b/app/models/map.rb
@@ -20,5 +20,4 @@ class Map < ApplicationRecord
       }
     end
   end
-
 end

--- a/app/models/map.rb
+++ b/app/models/map.rb
@@ -7,4 +7,18 @@ class Map < ApplicationRecord
   def self.ransackable_attributes(auth_object = nil)
     [ "address", "created_at", "id", "latitude", "longitude", "marker_image", "post_id", "updated_at" ]
   end
+
+  def self.locations_posts(posts)
+    locations = Map.joins(:post).where(posts: { id: posts.pluck(:id) })
+    locations.map do |location|
+      {
+        latitude: location.latitude,
+        longitude: location.longitude,
+        address: location.address,
+        marker_image: location.marker_image,
+        link: Rails.application.routes.url_helpers.post_path(location.post_id)
+      }
+    end
+  end
+
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -10,8 +10,11 @@ class Post < ApplicationRecord
   has_one :map, dependent: :destroy
   accepts_nested_attributes_for :map
 
+  scope :latest, -> { order(created_at: :desc).limit(10) }
+  scope :old, -> { order(created_at: :asc).limit(10) }
+
   def self.ransackable_attributes(auth_object = nil)
-    [ "comment", "created_at", "id", "location", "post_images", "temple_name", "updated_at", "user_id" ]
+    [ "comment", "created_at", "id", "post_images", "temple_name", "updated_at", "user_id" ]
   end
 
   def self.ransackable_associations(auth_object = nil)

--- a/app/views/posts/_search_form.html.erb
+++ b/app/views/posts/_search_form.html.erb
@@ -2,17 +2,18 @@
   <%= search_form_for @q, html: { class: "flex flex-row w-full space-x-4" } do |f| %>
     <!-- 寺院名または本文検索窓 -->
     <div class="relative flex-grow input input-bordered">
-      <%= f.search_field :temple_name_or_comment_cont, placeholder: "寺院名,本文", class: "w-full p-2 text-sm h-12" %>
+      <%= f.search_field :temple_name_or_comment_cont, placeholder: "タイトル、本文で検索", class: "w-full p-2 text-sm h-12" %>
     </div>
 
     <!-- 場所検索窓 -->
     <div class="relative flex-grow input input-bordered">
-      <%= f.search_field :map_address_cont, placeholder: "場所", class: "w-full p-2 text-sm h-12" %>
+      <%= f.search_field :map_address_cont, placeholder: "場所で検索", class: "w-full p-2 text-sm h-12" %>
     </div>
 
     <!-- 検索ボタン -->
     <div>
-      <%= f.submit "検索", class: "rounded border text-black bg-gradient-to-r from-[#a48953] to-[#8c7444] hover:from-white hover:to-white hover:text-gold1 hover:border-gold1 px-4 py-3 text-sm" %>
+      <%= f.submit "検索", class: "rounded border text-black bg-gradient-to-r from-[#a48953] to-[#8c7444] hover:from-white hover:to-white hover:text-gold1 hover:border-gold1 px-4 py-3 text-sm",
+       data: (@no_results ? { turbo_confirm: "検索結果が見つかりませんでした。" } : {}) %>
     </div>
   <% end %>
 </div>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -1,17 +1,19 @@
 <div class="py-1 sm:py-6 lg:py-7 mt-5">
   <div class="mx-auto max-w-screen-xl px-5 md:px-8">
+    <div class="flex justify-end mb-8"> <!-- ソートリンクをここに移動 -->
+      <%= link_to '新しい順', posts_path(latest: "true"), class: 'mr-2 hover:text-blue-500 underline' %>
+      <%= link_to '古い順', posts_path(old: "true"), class: 'hover:text-blue-500 underline' %>
+      <p>（10件）</p>
+    </div>
      <%= render 'search_form', q: @q, url: posts_path %>
     <div class="mb-5 md:mb-10">
       <h1 class="mb-4 text-center text-2xl font-bold md:mb-6 lg:text-3xl">投稿一覧</h1>
-      <p class="py-3 mx-auto max-w-screen-md text-center md:text-lg">あなたが訪れた寺院・史跡名跡を共有</p>
-       
+      <p class="py-3 mx-auto max-w-screen-md text-center md:text-lg">あなたが訪れた寺院・史跡名跡を共有</p>      
     </div>
     <div class="px-1 py-2 shadow-md" style="height: 750px;">
       <div id="index-map" class="w-full h-full max-w-screen-lg mx-auto"></div>
     </div>
-
   </div>
-    <%= paginate @posts %>
 </div>
 
 <script 


### PR DESCRIPTION
### 概要
 - 掲示板のソート機能の実装。
 - 降順または昇順で１０件ずつ表示されるようなっている。
 - `PostController`のマップ取得情報取得メソッドをモデルに移譲

### 詳細
 - `post.rb`においてscopeを作成し降順、昇順で掲示板を表示できるように設定
```
 scope :latest, -> { order(created_at: :desc).limit(10) }
 scope :old, -> { order(created_at: :asc).limit(10) }
```
 - `map.rb`に全ポスト情報収集のメソッド移動
 ```
  def self.locations_posts(posts)
    locations = Map.joins(:post).where(posts: { id: posts.pluck(:id) })
    locations.map do |location|
      {
        latitude: location.latitude,
        longitude: location.longitude,
        address: location.address,
        marker_image: location.marker_image,
        link: Rails.application.routes.url_helpers.post_path(location.post_id)
      }
    end
```