### PR TITLE
Rails Admin用のアセットプリコンパイル設定を修正

### DIFF
--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -11,7 +11,8 @@ Rails.application.config.assets.version = "1.0"
 # folder are already added.
 # Rails.application.config.assets.precompile += %w[ admin.js admin.css ]
 # config/initializers/assets.rb
-# Rails.application.config.assets.precompile += %w[ rails_admin/application.css rails_admin/application.js ]
+Rails.application.config.assets.precompile += %w[ rails_admin/application.css rails_admin/application.js ]
+
 Rails.application.config.assets.paths += [
     Rails.root.join("node_modules"),
     Rails.root.join("app/assets/stylesheets")


### PR DESCRIPTION
### 概要
 - `config/initializers/assets.rb` ファイル内で Rails Admin のアセットプリコンパイル設定を修正
 -  `rails_admin/application.css` と `rails_admin/application.js` をプリコンパイルリストに追加。